### PR TITLE
Add NASDAQ prediction example with Kronos-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ Running this script will generate a plot comparing the ground truth data against
 
 Additionally, we also provide a script that makes predictions without Volume and Amount data, which can be found in [`examples/prediction_wo_vol_example.py`](examples/prediction_wo_vol_example.py).
 
+#### NASDAQ 3-Month Forecast Example
+
+To forecast U.S. markets, `examples/nasdaq_prediction.py` downloads recent daily OHLCV data for the NASDAQ Composite (^IXIC), uses `Kronos-base` to project the next 60 trading days (~3 months), and visualizes the results as a candlestick chart.
+
+```bash
+python examples/nasdaq_prediction.py
+```
+
+
+
 
 ## 🔧 Finetuning on Your Own Data (A-Share Market Example)
 

--- a/examples/nasdaq_prediction.py
+++ b/examples/nasdaq_prediction.py
@@ -1,0 +1,77 @@
+import sys
+import pandas as pd
+import yfinance as yf
+import mplfinance as mpf
+import torch
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from model import Kronos, KronosTokenizer, KronosPredictor
+
+
+def main():
+    """Forecast NASDAQ Composite (^IXIC) for the next 3 months using Kronos-base."""
+    # configuration
+    lookback = 512  # maximum context length for Kronos-base
+    pred_len = 60   # ~3 months of trading days
+
+    # 1. Load historical daily data from Yahoo Finance
+    df = yf.download("^IXIC", period="3y", interval="1d")
+    df = df.droplevel(1, axis=1)
+    df = df.reset_index()
+    df.rename(columns={
+        "Date": "timestamps",
+        "Open": "open",
+        "High": "high",
+        "Low": "low",
+        "Close": "close",
+        "Volume": "volume",
+    }, inplace=True)
+    df = df[["timestamps", "open", "high", "low", "close", "volume"]]
+
+    # prepare lookback window
+    x_df = df.iloc[-lookback:, 1:]
+    x_timestamp = df.iloc[-lookback:, 0]
+    last_date = x_timestamp.iloc[-1]
+    y_timestamp = pd.Series(pd.bdate_range(start=last_date + pd.Timedelta(days=1), periods=pred_len))
+
+    # 2. Load Kronos-base model and tokenizer
+    tokenizer = KronosTokenizer.from_pretrained("NeoQuasar/Kronos-Tokenizer-base")
+    model = Kronos.from_pretrained("NeoQuasar/Kronos-base")
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    predictor = KronosPredictor(model, tokenizer, device=device, max_context=512)
+
+    # 3. Forecast future K-lines
+    pred_df = predictor.predict(
+        df=x_df,
+        x_timestamp=x_timestamp,
+        y_timestamp=y_timestamp,
+        pred_len=pred_len,
+        T=1.0,
+        top_p=0.9,
+        sample_count=1,
+        verbose=True,
+    )
+
+    print("Forecasted Data Head:")
+    print(pred_df.head())
+
+    # 4. Combine historical and predicted data
+    hist_df = x_df.copy()
+    hist_df.index = pd.DatetimeIndex(x_timestamp)
+    pred_df = pred_df[["open", "high", "low", "close", "volume"]]
+    pred_df.index = pd.DatetimeIndex(y_timestamp)
+    combined_df = pd.concat([hist_df, pred_df])
+
+    # 5. Plot candlestick chart
+    plot_df = combined_df.rename(columns={"open": "Open", "high": "High", "low": "Low", "close": "Close", "volume": "Volume"})
+    mpf.plot(
+        plot_df,
+        type="candle",
+        volume=True,
+        style="charles",
+        title="NASDAQ Composite (^IXIC) Forecast - Next 3 Months",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ torch
 
 einops==0.8.1
 huggingface_hub==0.33.1
+safetensors
 matplotlib==3.9.3
 pandas==2.2.2
 tqdm==4.67.1
+
+yfinance
+mplfinance


### PR DESCRIPTION
## Summary
- add `yfinance`, `mplfinance`, and `safetensors` dependencies
- include `nasdaq_prediction.py` example to forecast 3 months of NASDAQ Composite using Kronos-base
- document the new example in README

## Testing
- `pip install -r requirements.txt`
- `python examples/nasdaq_prediction.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6ab2046b48328aef80592ebb574ef