### PR TITLE
Add S&P 500 Kronos backtest pipeline

### DIFF
--- a/us_backtest/README.md
+++ b/us_backtest/README.md
@@ -1,0 +1,32 @@
+# Kronos US Backtest
+
+This directory provides a one-click script to reproduce a Kronos-style backtest on the S&P 500 universe.
+
+## Requirements
+
+- Python >= 3.10
+- `torch`, `numpy`, `pandas`, `matplotlib`, `tqdm`, `yfinance`
+- Kronos pretrained weights: place `Kronos-base` and `Kronos-Tokenizer-base` in your HuggingFace cache or local path so that
+  `KronosTokenizer.from_pretrained` and `Kronos.from_pretrained` can load them.
+  Download from: https://huggingface.co/NeoQuasar/Kronos-base
+
+## Usage
+
+```bash
+python us_backtest/run_kronos_us.py \
+    --universe sp500 \
+    --start 2015-01-01 \
+    --end 2025-08-31 \
+    --k 50 --n 5 --cost_bps 15 \
+    --H 10 --lookback 90 --min_hold 5 --samples 20
+```
+
+All outputs are saved under `outputs/us_backtest/`:
+
+- `signals.parquet` – daily expected returns per ticker
+- `trades.parquet` – executed trades and costs
+- `nav.csv` – portfolio, benchmark and excess NAV
+- `summary.json` – AER, IR, volatility, win rate, max drawdown and turnover
+- `cum_return.png` / `cum_excess_return.png` – performance plots
+
+Set the `--universe` argument to a comma-separated list of tickers to run on a custom universe.

--- a/us_backtest/backtest_topk_dropn.py
+++ b/us_backtest/backtest_topk_dropn.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from utils import (
+    annualized_return,
+    information_ratio,
+    max_drawdown,
+    plot_nav,
+    plot_excess_nav,
+    ensure_dir,
+    save_json,
+)
+
+
+@dataclass
+class Position:
+    shares: float
+    days: int
+
+
+def backtest(
+    signals: pd.DataFrame,
+    prices: pd.DataFrame,
+    benchmark: pd.Series,
+    out_dir: str,
+    k: int = 50,
+    n: int = 5,
+    min_hold: int = 5,
+    cost: float = 0.0015,
+) -> None:
+    ensure_dir(out_dir)
+
+    dates = sorted(prices.index.get_level_values(0).unique())
+    positions: Dict[str, Position] = {}
+    cash = 1.0
+    nav_list: List[float] = []
+    trade_records = []
+    turnover_list: List[float] = []
+
+    bench_prices = benchmark.reindex(dates).fillna(method="ffill")
+    bench_nav = [1.0]
+
+    prev_value = 1.0
+
+    for i in range(1, len(dates)):
+        date = dates[i]
+        prev_date = dates[i - 1]
+        open_prices = prices.xs(date, level=0)["open"]
+        close_prices = prices.xs(date, level=0)["close"]
+        signal_prev = signals.loc[prev_date].dropna() if prev_date in signals.index else pd.Series(dtype=float)
+        ranking = signal_prev.sort_values(ascending=False)
+        topk = set(ranking.head(k).index)
+
+        for pos in positions.values():
+            pos.days += 1
+
+        sell_candidates = [t for t in positions if (t not in topk) and positions[t].days >= min_hold]
+        sell_candidates.sort(key=lambda x: ranking.get(x, -np.inf))
+        sells = sell_candidates[:n]
+
+        for tk in sells:
+            if tk not in open_prices:
+                continue
+            price = open_prices[tk]
+            share = positions[tk].shares
+            amount = share * price
+            cost_pay = amount * cost
+            cash += amount - cost_pay
+            trade_records.append({"date": date, "ticker": tk, "action": "sell", "shares": share, "price": price, "amount": amount, "cost": cost_pay})
+            del positions[tk]
+
+        buys = []
+        for tk in ranking.index:
+            if tk in positions:
+                continue
+            if tk not in open_prices:
+                continue
+            buys.append(tk)
+            if len(buys) >= min(n, k - len(positions)):
+                break
+
+        buy_cash = cash / max(len(buys), 1)
+        for tk in buys:
+            price = open_prices[tk]
+            amount = buy_cash
+            share = amount / price
+            cost_pay = amount * cost
+            cash -= amount + cost_pay
+            positions[tk] = Position(share, 0)
+            trade_records.append({"date": date, "ticker": tk, "action": "buy", "shares": share, "price": price, "amount": amount, "cost": cost_pay})
+
+        value = cash
+        for tk, pos in positions.items():
+            if tk in close_prices:
+                value += pos.shares * close_prices[tk]
+        nav_list.append(value)
+        turnover = (sum(abs(rec["amount"]) for rec in trade_records if rec["date"] == date) / prev_value)
+        turnover_list.append(turnover)
+        prev_value = value
+
+        bench_ret = bench_prices.loc[date] / bench_prices.loc[dates[0]]
+        bench_nav.append(bench_ret)
+
+    nav_series = pd.Series(nav_list, index=dates[1:])
+    bench_series = pd.Series(bench_nav[1:], index=dates[1:])
+    excess_nav = nav_series / bench_series
+
+    nav_df = pd.DataFrame({"nav": nav_series, "bench_nav": bench_series, "excess_nav": excess_nav})
+    nav_df.to_csv(f"{out_dir}/nav.csv")
+
+    plot_nav(nav_series, bench_series, f"{out_dir}/cum_return.png")
+    plot_excess_nav(excess_nav, f"{out_dir}/cum_excess_return.png")
+
+    trades_df = pd.DataFrame(trade_records)
+    trades_df.to_parquet(f"{out_dir}/trades.parquet")
+
+    daily_ret = nav_series.pct_change().dropna()
+    bench_ret = bench_series.pct_change().dropna()
+    excess_ret = daily_ret - bench_ret
+    summary = {
+        "AER": annualized_return(excess_ret),
+        "IR": information_ratio(excess_ret),
+        "vol": daily_ret.std() * np.sqrt(252),
+        "win_rate": float((excess_ret > 0).mean()),
+        "max_drawdown": float(max_drawdown(nav_series)),
+        "turnover": float(np.mean(turnover_list)),
+    }
+    save_json(summary, f"{out_dir}/summary.json")
+
+    signals.to_parquet(f"{out_dir}/signals.parquet")

--- a/us_backtest/data_us.py
+++ b/us_backtest/data_us.py
@@ -1,0 +1,67 @@
+from typing import List
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+
+from utils import calc_time_features
+
+
+SP500_FALLBACK = [
+    "AAPL", "MSFT", "GOOGL", "AMZN", "META", "NVDA", "BRK-B", "JPM", "JNJ", "V"
+]
+
+
+def get_sp500_tickers(date: str | None = None) -> List[str]:
+    """Fetch S&P500 constituents from Wikipedia, fallback to yfinance or a static list."""
+    try:
+        tables = pd.read_html("https://en.wikipedia.org/wiki/List_of_S%26P_500_companies")
+        symbols = tables[0]["Symbol"].tolist()
+        symbols = [s.replace(".", "-") for s in symbols]
+        if symbols:
+            return symbols
+    except Exception:
+        pass
+
+    try:
+        return yf.tickers_sp500()
+    except Exception:
+        return SP500_FALLBACK
+
+
+def download_ohlcv(tickers: List[str], start: str, end: str) -> pd.DataFrame:
+    """Download OHLCV data for tickers using yfinance."""
+    data = yf.download(tickers, start=start, end=end, auto_adjust=False, progress=False, group_by="ticker")
+    if isinstance(data.columns, pd.MultiIndex):
+        data = data.stack(level=1).rename_axis(index=["date", "ticker"]).reset_index()
+    else:  # single ticker
+        data = data.reset_index()
+        data["ticker"] = tickers[0]
+    data.columns = [c.lower().replace(" ", "_") for c in data.columns]
+    data["amount"] = data["close"] * data["volume"]
+    data = data.set_index(["date", "ticker"])[["open", "high", "low", "close", "volume", "amount"]]
+    data = data.sort_index()
+    return data
+
+
+def prepare_windows(df: pd.DataFrame, lookback: int, horizon: int, batch_size: int = 64):
+    """Yield sliding windows for each ticker for inference."""
+    for ticker in df.index.get_level_values(1).unique():
+        tdf = df.xs(ticker, level=1)
+        tdf = tdf.dropna()
+        arr = tdf.values
+        dates = tdf.index
+        time_arr = calc_time_features(dates).values
+        n = len(tdf)
+        if n < lookback + horizon:
+            continue
+        for start in range(lookback - 1, n - horizon, batch_size):
+            end = min(n - horizon, start + batch_size)
+            batch_x, batch_x_stamp, batch_y_stamp, signal_dates = [], [], [], []
+            for t in range(start, end):
+                s = t - lookback + 1
+                batch_x.append(arr[s : s + lookback])
+                batch_x_stamp.append(time_arr[s : s + lookback])
+                batch_y_stamp.append(time_arr[t + 1 : t + 1 + horizon])
+                signal_dates.append(dates[t])
+            yield ticker, np.array(batch_x), np.array(batch_x_stamp), np.array(batch_y_stamp), signal_dates

--- a/us_backtest/kronos_infer.py
+++ b/us_backtest/kronos_infer.py
@@ -1,0 +1,64 @@
+from typing import Tuple
+
+import numpy as np
+import torch
+
+from model import Kronos, KronosTokenizer, auto_regressive_inference
+
+
+def load_model(device: torch.device) -> Tuple[KronosTokenizer, Kronos]:
+    """Load pretrained Kronos tokenizer and model."""
+    try:
+        tokenizer = KronosTokenizer.from_pretrained("NeoQuasar/Kronos-Tokenizer-base")
+        model = Kronos.from_pretrained("NeoQuasar/Kronos-base")
+    except Exception as e:
+        print(
+            "Pretrained Kronos weights not found. Please download from https://huggingface.co/NeoQuasar/ and place them so that KronosTokenizer.from_pretrained and Kronos.from_pretrained can load them.")
+        raise SystemExit(1)
+
+    tokenizer.eval()
+    model.eval()
+    tokenizer.to(device)
+    model.to(device)
+    return tokenizer, model
+
+
+def predict_batch(
+    tokenizer: KronosTokenizer,
+    model: Kronos,
+    x: np.ndarray,
+    x_stamp: np.ndarray,
+    y_stamp: np.ndarray,
+    device: torch.device,
+    samples: int,
+    T: float,
+    top_p: float,
+) -> np.ndarray:
+    """Predict future sequences for a batch of windows."""
+    x_mean = x.mean(axis=1, keepdims=True)
+    x_std = x.std(axis=1, keepdims=True)
+    x_norm = (x - x_mean) / (x_std + 1e-5)
+    x_norm = np.clip(x_norm, -5, 5)
+
+    x_tensor = torch.from_numpy(x_norm.astype(np.float32)).to(device)
+    x_stamp_tensor = torch.from_numpy(x_stamp.astype(np.float32)).to(device)
+    y_stamp_tensor = torch.from_numpy(y_stamp.astype(np.float32)).to(device)
+
+    preds = auto_regressive_inference(
+        tokenizer,
+        model,
+        x_tensor,
+        x_stamp_tensor,
+        y_stamp_tensor,
+        max_context=512,
+        pred_len=y_stamp.shape[1],
+        clip=5,
+        T=T,
+        top_k=0,
+        top_p=top_p,
+        sample_count=samples,
+        verbose=False,
+    )
+
+    preds = preds * (x_std + 1e-5) + x_mean
+    return preds

--- a/us_backtest/run_kronos_us.py
+++ b/us_backtest/run_kronos_us.py
@@ -1,0 +1,75 @@
+import argparse
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import torch
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+if CURRENT_DIR not in sys.path:
+    sys.path.append(CURRENT_DIR)
+
+from utils import set_seed
+from data_us import get_sp500_tickers, download_ohlcv, prepare_windows
+from kronos_infer import load_model, predict_batch
+from backtest_topk_dropn import backtest
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Kronos US backtest")
+    parser.add_argument("--universe", default="sp500")
+    parser.add_argument("--start", default="2015-01-01")
+    parser.add_argument("--end", default="2025-08-31")
+    parser.add_argument("--k", type=int, default=50)
+    parser.add_argument("--n", type=int, default=5)
+    parser.add_argument("--cost_bps", type=float, default=15)
+    parser.add_argument("--H", type=int, default=10)
+    parser.add_argument("--lookback", type=int, default=90)
+    parser.add_argument("--min_hold", type=int, default=5)
+    parser.add_argument("--samples", type=int, default=20)
+    parser.add_argument("--out_dir", default="outputs/us_backtest")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    set_seed(args.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    if args.universe == "sp500":
+        tickers = get_sp500_tickers()
+    else:
+        tickers = args.universe.split(",")
+
+    prices = download_ohlcv(tickers, args.start, args.end)
+    tokenizer, model = load_model(device)
+
+    signal_records = []
+    for ticker, x, x_stamp, y_stamp, dates in prepare_windows(prices, args.lookback, args.H):
+        preds = predict_batch(tokenizer, model, x, x_stamp, y_stamp, device, args.samples, 1.0, 0.9)
+        mean_close = preds[:, :, 3].mean(axis=1)
+        close_t = x[:, -1, 3]
+        ret = (mean_close - close_t) / close_t
+        df_sig = pd.DataFrame({"date": dates, "ticker": ticker, "signal": ret})
+        signal_records.append(df_sig)
+
+    if not signal_records:
+        raise SystemExit("No signals generated. Check data availability.")
+
+    signal_df = pd.concat(signal_records).set_index(["date", "ticker"]).unstack("ticker")["signal"].sort_index()
+
+    bench = download_ohlcv(["^GSPC"], args.start, args.end).xs("^GSPC", level=1)["close"]
+
+    backtest(
+        signals=signal_df,
+        prices=prices,
+        benchmark=bench,
+        out_dir=args.out_dir,
+        k=args.k,
+        n=args.n,
+        min_hold=args.min_hold,
+        cost=args.cost_bps / 10000,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/us_backtest/utils.py
+++ b/us_backtest/utils.py
@@ -1,0 +1,85 @@
+import os
+import random
+import json
+import math
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+import torch
+
+
+def set_seed(seed: int = 42) -> None:
+    """Set random seed for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def ensure_dir(path: str) -> None:
+    """Create directory if it does not exist."""
+    os.makedirs(path, exist_ok=True)
+
+
+def save_json(obj: dict, path: str) -> None:
+    with open(path, "w") as f:
+        json.dump(obj, f, indent=2)
+
+
+def calc_time_features(dt_index: pd.DatetimeIndex) -> pd.DataFrame:
+    """Create time feature dataframe compatible with Kronos tokenizer."""
+    df = pd.DataFrame(index=dt_index)
+    df["minute"] = 0
+    df["hour"] = 0
+    df["weekday"] = dt_index.weekday
+    df["day"] = dt_index.day
+    df["month"] = dt_index.month
+    return df[["minute", "hour", "weekday", "day", "month"]]
+
+
+def annualized_return(excess_returns: Iterable[float]) -> float:
+    arr = np.array(list(excess_returns))
+    if len(arr) == 0:
+        return 0.0
+    prod = np.prod(1 + arr)
+    return prod ** (252 / len(arr)) - 1
+
+
+def information_ratio(excess_returns: Iterable[float]) -> float:
+    arr = np.array(list(excess_returns))
+    if arr.std() == 0:
+        return 0.0
+    return arr.mean() / arr.std() * math.sqrt(252)
+
+
+def max_drawdown(nav: Iterable[float]) -> float:
+    arr = np.array(list(nav))
+    cum_max = np.maximum.accumulate(arr)
+    drawdown = (arr - cum_max) / cum_max
+    return drawdown.min()
+
+
+def plot_nav(nav: pd.Series, bench: pd.Series, path: str) -> None:
+    plt.figure(figsize=(10, 6))
+    plt.plot(nav.index, nav.values, label="Portfolio")
+    plt.plot(bench.index, bench.values, label="Benchmark")
+    plt.legend()
+    plt.xlabel("Date")
+    plt.ylabel("Cumulative Return")
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()
+
+
+def plot_excess_nav(excess_nav: pd.Series, path: str) -> None:
+    plt.figure(figsize=(10, 6))
+    plt.plot(excess_nav.index, excess_nav.values, label="Excess")
+    plt.legend()
+    plt.xlabel("Date")
+    plt.ylabel("Cumulative Excess Return")
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()


### PR DESCRIPTION
## Summary
- add `us_backtest` package with data download, model inference and top-k/drop-n backtest
- include one-click script `run_kronos_us.py` for full S&P 500 evaluation
- document usage and expected outputs in `us_backtest/README.md`

## Testing
- `python -m py_compile us_backtest/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7eb1cd3f48328b862247c92ca72bc