### PR TITLE
Fix Kronos weight loading by adding safetensors dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ torch
 
 einops==0.8.1
 huggingface_hub==0.33.1
+safetensors>=0.4.3
 matplotlib==3.9.3
 pandas==2.2.2
 tqdm==4.67.1

--- a/us_backtest/kronos_infer.py
+++ b/us_backtest/kronos_infer.py
@@ -8,13 +8,18 @@ from model.kronos import auto_regressive_inference
 
 
 def load_model(device: torch.device) -> Tuple[KronosTokenizer, Kronos]:
-    """Load pretrained Kronos tokenizer and model."""
+    """Load pretrained Kronos tokenizer and model.
+
+    Weights are fetched from the Hugging Face Hub if not already cached.
+    """
     try:
         tokenizer = KronosTokenizer.from_pretrained("NeoQuasar/Kronos-Tokenizer-base")
         model = Kronos.from_pretrained("NeoQuasar/Kronos-base")
     except Exception as e:
         print(
-            "Pretrained Kronos weights not found. Please download from https://huggingface.co/NeoQuasar/ and place them so that KronosTokenizer.from_pretrained and Kronos.from_pretrained can load them.")
+            "Failed to load pretrained Kronos weights. Ensure all dependencies (e.g., 'safetensors') are installed and that the model identifiers are correct."
+        )
+        print(f"Original error: {e}")
         raise SystemExit(1)
 
     tokenizer.eval()


### PR DESCRIPTION
## Summary
- add `safetensors` requirement so Hugging Face weights load automatically
- clarify `load_model` to fetch weights from the hub and show informative errors

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import torch
from us_backtest.kronos_infer import load_model
load_model(torch.device('cpu'))
print('loaded successfully')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68be49983770832884ad0e5dcba7b284